### PR TITLE
Sudo for Bazel Install

### DIFF
--- a/build_tensorflow/build_tensorflow.sh
+++ b/build_tensorflow/build_tensorflow.sh
@@ -95,8 +95,8 @@ function build_bazel()
     log_failure_msg "error when compile bazel"
     exit 1
   }
-  cp -a output/bazel /usr/local/bin/
-  chmod +x /usr/local/bin/bazel
+  sudo cp -a output/bazel /usr/local/bin/
+  sudo chmod +x /usr/local/bin/bazel
   return 0
 }
 

--- a/build_tensorflow/build_tensorflow.sh
+++ b/build_tensorflow/build_tensorflow.sh
@@ -95,8 +95,14 @@ function build_bazel()
     log_failure_msg "error when compile bazel"
     exit 1
   }
-  sudo cp -a output/bazel /usr/local/bin/
-  sudo chmod +x /usr/local/bin/bazel
+
+  chmod +x output/bazel
+  if [ -w /usr/local/ ]; then
+    cp output/bazel /usr/local/bin/
+  else
+    sudo cp output/bazel /usr/local/bin/
+  fi
+
   return 0
 }
 


### PR DESCRIPTION
The script fails on my system when trying to installed Bazel with a Permission Denied error. By using sudo on the copy and chmod the process succeeds.