### PR TITLE
Git reset before checkout

### DIFF
--- a/build_tensorflow/build_tensorflow.sh
+++ b/build_tensorflow/build_tensorflow.sh
@@ -130,6 +130,7 @@ function download_tensorflow()
   else
     cd tensorflow/
     bazel clean &>/dev/null
+    git reset --hard
     git checkout master
     git branch -D __temp__
   fi


### PR DESCRIPTION
When the script tries to checkout master it will fail if the repo is not a fresh clone due to modified files. This change allows the same repo to be reused multiple times, for debugging or multiple configs, etc.