### PR TITLE
fixup: Report failure message if we failed to build bazel

### DIFF
--- a/build_tensorflow/build_tensorflow.sh
+++ b/build_tensorflow/build_tensorflow.sh
@@ -103,10 +103,11 @@ function build_bazel()
     cd bazel-${BAZEL_VERSION}/
   fi
 
-  ./compile.sh || {
+  ./compile.sh
+  if [ ! -f ./output/bazel ]; then
     log_failure_msg "error when compile bazel"
     exit 1
-  }
+  fi
 
   chmod +x output/bazel
   mv output/bazel $BAZEL_BIN


### PR DESCRIPTION
Java may crash while compiling bazel if you only have 2GB RAM or less.
Do not believe the return value of compile.sh. Check the output binary
instead.

This patch will make it easier for me to debug what breaks my build process on my VMware machine with less than 2GB RAM configured...
See also: #20 