### PR TITLE
Allow local toolchains without download URL

### DIFF
--- a/build_tensorflow/build_tensorflow.sh
+++ b/build_tensorflow/build_tensorflow.sh
@@ -133,7 +133,7 @@ function build_bazel()
 
 function toolchain()
 {
-  [ "$CROSSTOOL_COMPILER" != "yes" ] && return 0
+  [ "$CROSSTOOL_COMPILER" != "yes" ] || [ -z "$CROSSTOOL_URL" ] && return 0
 
   CROSSTOOL_DIR="${WORKDIR}/toolchain/${CROSSTOOL_DIR}/"
 
@@ -190,7 +190,7 @@ function download_tensorflow()
   fi
 
   if [ ! -z "$CROSSTOOL_DIR" ] && [ ! -z "$CROSSTOOL_NAME" ]; then
-    tf_toolchain_patch "$CROSSTOOL_NAME" "$CROSSTOOL_DIR" "$CROSSTOOL_EXTRA_INCLUDE" || {
+    tf_toolchain_patch "$CROSSTOOL_NAME" "$CROSSTOOL_DIR" "$CROSSTOOL_ROOT" "$CROSSTOOL_EXTRA_INCLUDE" || {
       log_failure_msg "error when apply crosstool patch"
       exit 1
     }

--- a/build_tensorflow/patch.sh
+++ b/build_tensorflow/patch.sh
@@ -24,7 +24,8 @@ function tf_toolchain_patch()
 {
   local CROSSTOOL_NAME="$1"
   local CROSSTOOL_DIR="$2"
-  local CROSSTOOL_EXTRA_INCLUDE="$3"
+  local CROSSTOOL_ROOT="$3"
+  local CROSSTOOL_EXTRA_INCLUDE="$4"
   [ -z "$CROSSTOOL_EXTRA_INCLUDE" ] && CROSSTOOL_EXTRA_INCLUDE="/usr/local/include/"
   local CROSSTOOL_VERSION=$($CROSSTOOL_DIR/bin/$CROSSTOOL_NAME-gcc -dumpversion)
   git apply << EOF
@@ -140,7 +141,7 @@ index bfe91e711b..da292cdcaf 100644
                              ],
                          ),
                      ],
-@@ -331,13 +330,21 @@ def _impl(ctx):
+@@ -331,17 +330,23 @@ def _impl(ctx):
                              flags = [
                                  "-std=c++11",
                                  "-isystem",
@@ -158,15 +159,19 @@ index bfe91e711b..da292cdcaf 100644
 +		                       "-isystem",
 +                        "$CROSSTOOL_DIR/lib/gcc/$CROSSTOOL_NAME/$CROSSTOOL_VERSION/include-fixed",
 +                               "-isystem",
-+                        "/usr/include",
++                        "$CROSSTOOL_ROOT/usr/include",
 +                               "-isystem",
-+                        "/usr/include/$CROSSTOOL_NAME",
++                        "$CROSSTOOL_ROOT/usr/include/$CROSSTOOL_NAME",
 +                               "-isystem",
 +                        "$CROSSTOOL_EXTRA_INCLUDE",
                                  "-isystem",
                                  "%{PYTHON_INCLUDE_PATH}%",
-                                 "-isystem",
-@@ -559,12 +566,14 @@ def _impl(ctx):
+-                                "-isystem",
+-                                "/usr/include/",
+                             ],
+                         ),
+                     ],
+@@ -559,12 +564,15 @@ def _impl(ctx):
 
      if (ctx.attr.cpu == "armeabi"):
          cxx_builtin_include_directories = [
@@ -179,14 +184,16 @@ index bfe91e711b..da292cdcaf 100644
 +                "$CROSSTOOL_DIR/$CROSSTOOL_NAME/libc/usr/include/",
 +		"$CROSSTOOL_DIR/lib/gcc/$CROSSTOOL_NAME/$CROSSTOOL_VERSION/include",
 +		"$CROSSTOOL_DIR/lib/gcc/$CROSSTOOL_NAME/$CROSSTOOL_VERSION/include-fixed",
-                 "/usr/include",
+-                "/usr/include",
++                "$CROSSTOOL_ROOT/usr/include",
 -                "/tmp/openblas_install/include/",
 +                "/usr/include/$CROSSTOOL_NAME",
 +                "$CROSSTOOL_EXTRA_INCLUDE",
++                "%{PYTHON_INCLUDE_PATH}%"
              ]
      elif (ctx.attr.cpu == "local"):
          cxx_builtin_include_directories = ["/usr/lib/gcc/", "/usr/local/include", "/usr/include"]
-@@ -579,44 +588,44 @@ def _impl(ctx):
+@@ -579,44 +587,44 @@ def _impl(ctx):
          tool_paths = [
              tool_path(
                  name = "ar",


### PR DESCRIPTION
People may want to build TensorFlow with a local toolchain that has no download URL. This pull request enables such scenarios by skipping the toolchain download when `$CROSSTOOL_URL` is empty.

In addition, this pull request enables scenarios where one works with a toolchain that is structured so that a `/usr/include` hierarchy for the headers is inside some other directory (configurable as `$CROSSTOOL_ROOT`) - not inside the absolute path `/usr/include`. If `$CROSSTOOL_ROOT` is left empty/unconfigured by a configuration, everything shall work as it did before this pull request.