### PR TITLE
Allow custom patches per conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ docker run -it -v /tmp/tensorflow_pkg/:/tmp/tensorflow_pkg/ --env TF_PYTHON_VERS
 
 ## Edit tweaks like bazel resources, board model, and others
 see configuration file examples in: build_tensorflow/configs/
+Configurations can have custom patches applied to TensorFlow or Bazel. Configure these by providing their paths inside the `TF_PATCH` and `BAZEL_PATCH` variables (relative to the `patch/tensorflow` or `patch/bazel` directories, respectively).
 
 ## Finally, compile tensorflow.
 ```shell

--- a/build_tensorflow/build_tensorflow.sh
+++ b/build_tensorflow/build_tensorflow.sh
@@ -108,8 +108,8 @@ function build_bazel()
     unzip bazel-${BAZEL_VERSION}-dist.zip -d bazel-${BAZEL_VERSION}/
     rm -f bazel-${BAZEL_VERSION}-dist.zip
     cd bazel-${BAZEL_VERSION}/
-    if [ "$BAZEL_PATCH" == "yes" ]; then
-      bazel_patch || {
+    if [ ! -z "$BAZEL_PATCH" ]; then
+      bazel_patch $BAZEL_PATCH || {
         log_failure_msg "error when apply patch"
         exit 1
       }
@@ -182,8 +182,8 @@ function download_tensorflow()
   git config user.email "temp@example.com"
   git config user.name "temp"
 
-  if [ "$TF_PATCH" == "yes" ]; then
-     tf_patch || {
+  if [ ! -z "$TF_PATCH" ]; then
+     tf_patch $TF_PATCH || {
        log_failure_msg "error when apply patch"
        exit 1
      }

--- a/build_tensorflow/patch.sh
+++ b/build_tensorflow/patch.sh
@@ -4,6 +4,9 @@ PATCH_DIR="$(dirname ${BASH_SOURCE[0]})"
 
 function bazel_patch()
 {
+  if [ "$1" != "yes" ] && [ -f "${PATCH_DIR}/patch/bazel/$1" ]; then
+    patch -p1 < "${PATCH_DIR}/patch/bazel/$1"
+  fi
   [ ! -d "${PATCH_DIR}/patch/bazel/${BAZEL_VERSION}" ] && return 0
   for f in $(find "${PATCH_DIR}/patch/bazel/${BAZEL_VERSION}" -type f | sort); do
     patch -p1 < "$f" || return 1
@@ -13,6 +16,9 @@ function bazel_patch()
 
 function tf_patch()
 {
+  if [ "$1" != "yes" ] && [ -f "${PATCH_DIR}/patch/tensorflow/$1" ]; then
+    git apply "${PATCH_DIR}/patch/tensorflow/$1"
+  fi
   [ ! -d "${PATCH_DIR}/patch/tensorflow/${TF_VERSION}" ] && return 0
   for f in $(find "${PATCH_DIR}/patch/tensorflow/${TF_VERSION}" -type f | sort); do
     git apply "$f" || return 1


### PR DESCRIPTION
This allows a configuration to make custom patches to TensorFlow or to Bazel. These patches can be configured by providing their paths inside the `TF_PATCH` and `BAZEL_PATCH` variables (relative to the `patch/tensorflow` or `patch/bazel` directories, respectively). These patches are applied in addition to the ones that would be applied if `TF_PATCH` and `BAZEL_PATCH` were `yes`. If `TF_PATCH` and `BAZEL_PATCH` are `yes`, as in the current configurations, the behavior shall be the same as before this pull request. If `TF_PATCH` and `BAZEL_PATCH` are empty or not configured, the behavior shall be the same as before this pull request and no patches shall be applied.