### PR TITLE
Building TF 2.3.0 with Python 3.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,22 @@ apt-get install libpython-all-dev:armhf
 # For python3
 apt-get install libpython3-all-dev:armhf
 ```
-Using Docker
+### Using Docker
+
+#### Python 3.7
+
 ```shell
 cd build_tensorflow/
 docker build -t tf-arm -f Dockerfile .
 docker run -it -v /tmp/tensorflow_pkg/:/tmp/tensorflow_pkg/ --env TF_PYTHON_VERSION=3.7 tf-arm ./build_tensorflow.sh configs/<conf-name> # rpi.conf, rk3399.conf ...
+```
+
+#### Python 3.8
+
+```shell
+cd build_tensorflow/
+docker build -t tf-arm -f Dockerfile.bullseye .
+docker run -it -v /tmp/tensorflow_pkg/:/tmp/tensorflow_pkg/ --env TF_PYTHON_VERSION=3.8 tf-arm ./build_tensorflow.sh configs/<conf-name> # rpi.conf, rk3399.conf ...
 ```
 
 ## Edit tweaks like Bazel resources, board model, and others.

--- a/build_tensorflow/Dockerfile.bullseye
+++ b/build_tensorflow/Dockerfile.bullseye
@@ -1,0 +1,29 @@
+FROM debian:bullseye
+
+RUN dpkg --add-architecture armhf && dpkg --add-architecture arm64 \
+    && apt-get update && apt-get install -y \
+        openjdk-11-jdk automake autoconf libpng-dev \
+        curl zip unzip libtool swig zlib1g-dev pkg-config git wget xz-utils \
+        python3-numpy python3-pip python3-mock \
+        libpython3-dev libpython3-all-dev \
+        libpython3-dev:armhf libpython3-all-dev:armhf \
+        libpython3-dev:arm64 libpython3-all-dev:arm64
+
+# NOTE: forcing gcc 8.3 as default (prevents internal compiler error: in emit_move_insn, at expr.c bug in gcc-6 of stretch)
+RUN echo "deb http://ftp.us.debian.org/debian/ buster main contrib non-free" > /etc/apt/sources.list.d/buster.list \
+    && apt-get update && apt-get install -y --allow-downgrades gcc-8 g++-8 gcc=4:8.3.0-1 g++=4:8.3.0-1 cpp=4:8.3.0-1\
+    && rm -f /etc/apt/sources.list.d/buster.list \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip3 install -U --user keras_applications==1.0.8 --no-deps \
+    && pip3 install -U --user keras_preprocessing==1.1.0 --no-deps \
+    && ldconfig
+
+RUN /bin/bash -c "update-alternatives --install /usr/bin/python python /usr/bin/python3 150"
+
+WORKDIR /root
+RUN git clone https://github.com/lhelontra/tensorflow-on-arm/
+
+WORKDIR /root/tensorflow-on-arm/build_tensorflow/
+RUN git checkout v2.3.0
+CMD ["/bin/bash"]

--- a/build_tensorflow/Dockerfile.bullseye
+++ b/build_tensorflow/Dockerfile.bullseye
@@ -4,10 +4,12 @@ RUN dpkg --add-architecture armhf && dpkg --add-architecture arm64 \
     && apt-get update && apt-get install -y \
         openjdk-11-jdk automake autoconf libpng-dev \
         curl zip unzip libtool swig zlib1g-dev pkg-config git wget xz-utils \
-        python3-numpy python3-pip python3-mock \
+        python3-pip python3-mock \
         libpython3-dev libpython3-all-dev \
         libpython3-dev:armhf libpython3-all-dev:armhf \
         libpython3-dev:arm64 libpython3-all-dev:arm64
+
+RUN pip install "numpy<1.19.0"
 
 # NOTE: forcing gcc 8.3 as default (prevents internal compiler error: in emit_move_insn, at expr.c bug in gcc-6 of stretch)
 RUN echo "deb http://ftp.us.debian.org/debian/ buster main contrib non-free" > /etc/apt/sources.list.d/buster.list \


### PR DESCRIPTION
I have just added a third Dockerfile called `Dockerfile.bullseye` with the related instructions in `README.md` document to install TF 2.3.0 with Python 3.8.

It fixes the issue #102 created by me and @fantinomaurizio.

Hope it helps!