### PR TITLE
chore : use --no-cache-dir flag to pip in dockerfiles to save space

### DIFF
--- a/build_tensorflow/Dockerfile
+++ b/build_tensorflow/Dockerfile
@@ -9,9 +9,9 @@ RUN dpkg --add-architecture armhf && dpkg --add-architecture arm64 \
         libpython3-dev:armhf libpython3-all-dev:armhf \
         libpython3-dev:arm64 libpython3-all-dev:arm64 g++ gcc
 
-RUN pip3 install -U --user keras_applications==1.0.8 --no-deps \
-    && pip3 install -U --user keras_preprocessing==1.1.0 --no-deps \
-    && pip3 install portpicker \
+RUN pip3 install --no-cache-dir -U --user keras_applications==1.0.8 --no-deps \
+    && pip3 install --no-cache-dir -U --user keras_preprocessing==1.1.0 --no-deps \
+    && pip3 install --no-cache-dir portpicker \
     && ldconfig
 
 RUN /bin/bash -c "update-alternatives --install /usr/bin/python python /usr/bin/python3 150"

--- a/build_tensorflow/Dockerfile.bullseye
+++ b/build_tensorflow/Dockerfile.bullseye
@@ -9,7 +9,7 @@ RUN dpkg --add-architecture armhf && dpkg --add-architecture arm64 \
         libpython3-dev:armhf libpython3-all-dev:armhf \
         libpython3-dev:arm64 libpython3-all-dev:arm64
 
-RUN pip install "numpy<1.19.0"
+RUN pip install --no-cache-dir "numpy<1.19.0"
 
 # NOTE: forcing gcc 8.3 as default (prevents internal compiler error: in emit_move_insn, at expr.c bug in gcc-6 of stretch)
 RUN echo "deb http://ftp.us.debian.org/debian/ buster main contrib non-free" > /etc/apt/sources.list.d/buster.list \
@@ -17,8 +17,8 @@ RUN echo "deb http://ftp.us.debian.org/debian/ buster main contrib non-free" > /
     && rm -f /etc/apt/sources.list.d/buster.list \
     && rm -rf /var/lib/apt/lists/*
 
-RUN pip3 install -U --user keras_applications==1.0.8 --no-deps \
-    && pip3 install -U --user keras_preprocessing==1.1.0 --no-deps \
+RUN pip3 install --no-cache-dir -U --user keras_applications==1.0.8 --no-deps \
+    && pip3 install --no-cache-dir -U --user keras_preprocessing==1.1.0 --no-deps \
     && ldconfig
 
 RUN /bin/bash -c "update-alternatives --install /usr/bin/python python /usr/bin/python3 150"

--- a/build_tensorflow/Dockerfile.stretch
+++ b/build_tensorflow/Dockerfile.stretch
@@ -15,9 +15,9 @@ RUN echo "deb http://ftp.us.debian.org/debian/ buster main contrib non-free" > /
     && rm -f /etc/apt/sources.list.d/buster.list \
     && rm -rf /var/lib/apt/lists/*
 
-RUN pip3 install -U --user keras_applications==1.0.8 --no-deps \
-    && pip3 install -U --user keras_preprocessing==1.1.0 --no-deps \
-    && pip3 install portpicker \
+RUN pip3 install --no-cache-dir -U --user keras_applications==1.0.8 --no-deps \
+    && pip3 install --no-cache-dir -U --user keras_preprocessing==1.1.0 --no-deps \
+    && pip3 install --no-cache-dir portpicker \
     && ldconfig
 
 RUN /bin/bash -c "update-alternatives --install /usr/bin/python python /usr/bin/python3 150"


### PR DESCRIPTION
using --no-cache-dir flag in pip install ,make sure downloaded packages
by pip don't cached on system . This is a best practice which make sure
to fetch from repo instead of using local cached one . Further , in case
of Docker Containers , by restricting caching , we can reduce image size.
In term of stats , it depends upon the number of python packages
multiplied by their respective size . e.g for heavy packages with a lot
of dependencies it reduce a lot by don't caching pip packages.

Further , more detail information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>